### PR TITLE
Add Dependabot configuration for Go modules and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: daily
+    target-branch: dev
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    target-branch: dev


### PR DESCRIPTION
This PR introduces a Dependabot configuration file that enables automatic updates for Go modules and GitHub Actions. The Go modules will be checked daily, while GitHub Actions will be updated weekly, both targeting the `dev` branch. This enhancement aims to streamline dependency management and ensure that the project remains up-to-date with the latest versions.